### PR TITLE
refactor(workflow): split metrics generation into isolated jobs per SVG

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -2,7 +2,7 @@ name: Generate README Assets
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # Daily at midnight UTC
   workflow_dispatch:
   push:
     branches: ["master", "main"]
@@ -14,7 +14,7 @@ jobs:
   generate-snake:
     name: Generate Snake Contribution Graph
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -23,66 +23,125 @@ jobs:
         uses: Platane/snk@v3
         with:
           github_user_name: OskaraOskar
-          outputs: |
-            dist/github-contribution-grid-snake.svg
+          outputs: dist/github-contribution-grid-snake.svg
 
-      - name: Deploy Snake SVG to Output Branch
-        uses: crazy-max/ghaction-github-pages@v4
+      - name: Upload Snake Artifact
+        uses: actions/upload-artifact@v4
         with:
-          target_branch: output
-          build_dir: dist
-          commit_message: "Deploy snake contribution graph"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: snake
+          path: dist/github-contribution-grid-snake.svg
 
-  classic-metrics:
-    name: Generate Classic GitHub Metrics
+  metrics-introduction:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate Classic Metrics
+      - name: Generate Introduction Metrics
         uses: lowlighter/metrics@latest
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           user: OskaraOskar
+          filename: dist/metrics.introduction.svg
           template: classic
-          filename: dist/github-metrics.svg
-          base: header, activity, community, repositories, metadata
-          config_timezone: Europe/Stockholm
+          base: ""
           plugin_introduction: yes
           plugin_introduction_title: yes
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics-introduction
+          path: dist/metrics.introduction.svg
+
+  metrics-activity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Generate Activity Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: OskaraOskar
+          filename: dist/metrics.activity.svg
+          template: classic
+          base: ""
           plugin_activity: yes
           plugin_activity_limit: 5
           plugin_activity_days: 14
           plugin_activity_visibility: all
           plugin_activity_timestamps: yes
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics-activity
+          path: dist/metrics.activity.svg
+
+  metrics-calendar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Generate Calendar Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: OskaraOskar
+          filename: dist/metrics.calendar.svg
+          template: classic
+          base: ""
           plugin_calendar: yes
           plugin_calendar_limit: 1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics-calendar
+          path: dist/metrics.calendar.svg
+
+  metrics-isocalendar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Generate Isometric Calendar Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: OskaraOskar
+          filename: dist/metrics.isocalendar.svg
+          template: classic
+          base: ""
           plugin_isocalendar: yes
           plugin_isocalendar_duration: half-year
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics-isocalendar
+          path: dist/metrics.isocalendar.svg
+
+  metrics-skyline:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    continue-on-error: true # Skyline is fancy but flaky
+    steps:
+      - name: Generate Skyline Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: OskaraOskar
+          filename: dist/metrics.skyline.svg
+          template: classic
+          base: ""
           plugin_skyline: yes
           plugin_skyline_year: current-year
-          plugin_skyline_frames: 24
-          plugin_skyline_quality: 0.3
+          plugin_skyline_frames: 12
+          plugin_skyline_quality: 0.2
           plugin_skyline_compatibility: yes
 
-      - name: Upload Classic Metrics Artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: classic-metrics
-          path: dist/github-metrics.svg
+          name: metrics-skyline
+          path: dist/metrics.skyline.svg
 
-  repository-metrics:
-    name: Generate Repository Metrics
+  metrics-repository:
     runs-on: ubuntu-latest
-    needs: classic-metrics
+    timeout-minutes: 3
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: Generate Repository Metrics
         uses: lowlighter/metrics@latest
         with:
@@ -95,20 +154,15 @@ jobs:
               "repository": "OskaraOskar"
             }
 
-      - name: Upload Repository Metrics Artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: repository-metrics
+          name: metrics-repository
           path: dist/metrics.repository.svg
 
-  terminal-metrics:
-    name: Generate Terminal Metrics
+  metrics-terminal:
     runs-on: ubuntu-latest
-    needs: classic-metrics
+    timeout-minutes: 3
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: Generate Terminal Metrics
         uses: lowlighter/metrics@latest
         with:
@@ -117,27 +171,39 @@ jobs:
           template: terminal
           filename: dist/metrics.terminal.svg
 
-      - name: Upload Terminal Metrics Artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: terminal-metrics
+          name: metrics-terminal
           path: dist/metrics.terminal.svg
 
-  deploy-metrics:
-    name: Deploy All Metrics
+  deploy-assets:
+    name: Deploy All Generated Assets
     runs-on: ubuntu-latest
-    needs: [repository-metrics, terminal-metrics]
+    needs:
+      - generate-snake
+      - metrics-introduction
+      - metrics-activity
+      - metrics-calendar
+      - metrics-isocalendar
+      - metrics-skyline
+      - metrics-repository
+      - metrics-terminal
     steps:
-      - name: Download all artifacts
+      - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
           path: dist
 
-      - name: Deploy All Metrics to Output Branch
+      - name: Flatten Directory
+        run: |
+          mkdir flat
+          find dist -type f -exec cp {} flat/ \;
+
+      - name: Deploy to Output Branch
         uses: crazy-max/ghaction-github-pages@v4
         with:
           target_branch: output
-          build_dir: dist
-          commit_message: "Deploy GitHub metrics"
+          build_dir: flat
+          commit_message: "Deploy all GitHub visual assets"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- One GitHub Action job per metrics plugin output (1 SVG = 1 job)
- Improves scalability, debuggability, and execution reliability
- Avoids Puppeteer timeouts and long-running monolithic jobs
- Centralized deploy step collects and publishes all artifacts
- Uses artifact upload/download and directory flattening