### PR TITLE
Refresh profile README and GitHub visuals

### DIFF
--- a/.github/workflows/github-stats.yml
+++ b/.github/workflows/github-stats.yml
@@ -1,233 +1,83 @@
-name: Generate README Assets
+name: Refresh GitHub profile visuals
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Daily at midnight UTC
-  workflow_dispatch:
+    - cron: "15 1 * * *"
   push:
-    branches: ["master", "main"]
+    paths:
+      - ".github/workflows/github-stats.yml"
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  generate-snake:
-    name: Generate Snake Contribution Graph
+  refresh-profile-visuals:
+    name: Refresh profile SVGs
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate Snake SVG
-        uses: Platane/snk@v3
+      - name: Check out the output branch
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          github_user_name: OskaraOskar
-          outputs: dist/github-contribution-grid-snake.svg
+          ref: output
+          fetch-depth: 1
 
-      - name: Upload Snake Artifact
-        uses: actions/upload-artifact@v4
+      - name: Check out the streak generator
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          name: snake
-          path: dist/github-contribution-grid-snake.svg
+          repository: DenverCoder1/github-readme-streak-stats
+          ref: 2c2e936823881ec94120a207d7a534520eeadf8f
+          path: .streak-generator
+          persist-credentials: false
 
-  metrics-calendar:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate Calendar Metrics
-        uses: lowlighter/metrics@latest
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # releases/v2
         with:
-          token: ${{ secrets.GH_STATS_TOKEN }}
-          user: OskaraOskar
-          filename: metrics.calendar.svg
-          template: classic
-          base: ""
-          plugin_calendar: yes
-          plugin_calendar_limit: 1
-          output_action: commit
-          committer_branch: output
-          committer_message: "Update calendar metrics"
+          php-version: "8.3"
+          extensions: intl, curl
+          coverage: none
+          github-token: ""
 
-      - name: Download generated file for artifacts
-        run: |
-          mkdir -p dist
-          # The file is committed to the output branch, but we also want it for artifacts
-          # We'll download it from the branch that was just updated
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               -H "Accept: application/vnd.github.v3.raw" \
-               -o dist/metrics.calendar.svg \
-               "https://api.github.com/repos/OskaraOskar/OskaraOskar/contents/metrics.calendar.svg?ref=output" || \
-          # Fallback: if the file doesn't exist yet, create a placeholder
-          cp dist/metrics.calendar.svg dist/metrics.calendar.svg 2>/dev/null || echo "<!-- Calendar metrics placeholder -->" > dist/metrics.calendar.svg
+      - name: Install generator dependencies
+        working-directory: .streak-generator
+        run: composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: metrics-calendar
-          path: dist/metrics.calendar.svg
-
-  metrics-habits:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate Isometric Calendar Metrics
-        uses: lowlighter/metrics@latest
-        with:
-          token: ${{ secrets.GH_STATS_TOKEN }}
-          user: OskaraOskar
-          filename: metrics.isocalendar.svg
-          base: ""
-          plugin_habits: yes
-          plugin_habits_facts: yes
-          plugin_habits_charts: yes
-          plugin_habits_charts_type: graph
-          config_timezone: Europe/Stockholm
-          output_action: commit
-          committer_branch: output
-          committer_message: "Update isocalendar metrics"
-
-      - name: Download generated file for artifacts
-        run: |
-          mkdir -p dist
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               -H "Accept: application/vnd.github.v3.raw" \
-               -o dist/metrics.isocalendar.svg \
-               "https://api.github.com/repos/OskaraOskar/OskaraOskar/contents/metrics.isocalendar.svg?ref=output" || \
-          echo "<!-- Isocalendar metrics placeholder -->" > dist/metrics.isocalendar.svg
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: metrics-isocalendar
-          path: dist/metrics.isocalendar.svg
-
-  metrics-skyline:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    continue-on-error: true
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate Skyline Metrics
-        uses: lowlighter/metrics@latest
-        with:
-          token: ${{ secrets.GH_STATS_TOKEN }}
-          user: OskaraOskar
-          filename: metrics.skyline.svg
-          template: classic
-          base: ""
-          plugin_skyline: yes
-          plugin_skyline_frames: 120
-          plugin_skyline_quality: 0.5
-          plugin_skyline_settings: |
-            {
-              "url": "https://honzaap.github.io/GithubCity/?name=OskaraOskar&year=2025",
-              "ready": "[...document.querySelectorAll('.display-info span')].map(span => span.innerText).includes('OskaraOskar')",
-              "wait": 4,
-              "hide": ".github-corner, .footer-link, .buttons-options, .mobile-rotate, .display-info span:first-child"
-            }          
-          output_action: commit
-          committer_branch: output
-          committer_message: "Update skyline metrics"
-
-      - name: Download generated file for artifacts
-        run: |
-          mkdir -p dist
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               -H "Accept: application/vnd.github.v3.raw" \
-               -o dist/metrics.skyline.svg \
-               "https://api.github.com/repos/OskaraOskar/OskaraOskar/contents/metrics.skyline.svg?ref=output" || \
-          echo "<!-- Skyline metrics placeholder -->" > dist/metrics.skyline.svg
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: metrics-skyline
-          path: dist/metrics.skyline.svg
-
-  metrics-user:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Generate User Metrics
-        uses: lowlighter/metrics@latest
-        with:
-          token: ${{ secrets.GH_STATS_TOKEN }}
-          user: OskaraOskar
-          filename: metrics.user.svg
-          template: classic
-          base: header, activity, repositories, metadata
-          output_action: commit
-          committer_branch: output
-          committer_message: "Update user metrics"
-
-      - name: Download generated file for artifacts
-        run: |
-          mkdir -p dist
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               -H "Accept: application/vnd.github.v3.raw" \
-               -o dist/metrics.user.svg \
-               "https://api.github.com/repos/OskaraOskar/OskaraOskar/contents/metrics.user.svg?ref=output" || \
-          echo "<!-- User metrics placeholder -->" > dist/metrics.user.svg
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: metrics-user
-          path: dist/metrics.user.svg
-
-  external-stats:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Create Output Directory
-        run: mkdir -p dist
-
-      - name: Fetch GitHub Readme Stats SVGs
-        run: |
-          curl -L "https://github-readme-stats-red-eight-40.vercel.app/api?username=OskaraOskar&show_icons=true&theme=radical&count_private=true&include_all_commits=true" -o dist/github-readme-stats.svg
-          curl -L "https://github-readme-stats-red-eight-40.vercel.app/api/top-langs/?username=OskaraOskar&layout=compact&theme=radical&count_private=true" -o dist/github-top-langs.svg
-          curl -L "https://github-readme-streak-stats.herokuapp.com/?user=OskaraOskar&theme=radical&hide_border=true" -o dist/github-streak-stats.svg
-
-      - name: Upload External Stats
-        uses: actions/upload-artifact@v4
-        with:
-          name: external-stats
-          path: dist/*.svg
-
-  deploy-assets:
-    name: Deploy All Generated Assets
-    runs-on: ubuntu-latest
-    needs:
-      - generate-snake
-      - metrics-calendar
-      - metrics-habits
-      - metrics-skyline
-      - metrics-user
-      - external-stats
-    steps:
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-
-      - name: Flatten Directory
-        run: |
-          mkdir flat
-          find dist -type f -exec cp {} flat/ \;
-
-      - name: Deploy to Output Branch
-        uses: crazy-max/ghaction-github-pages@v4
-        with:
-          target_branch: output
-          build_dir: flat
-          commit_message: "Deploy all GitHub visual assets"
+      - name: Require the private contribution token
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_STATS_TOKEN: ${{ secrets.GH_STATS_TOKEN }}
+        run: |
+          if [ -z "${GH_STATS_TOKEN}" ]; then
+            echo "::error::GH_STATS_TOKEN is required to generate the streak card."
+            exit 1
+          fi
+
+      - name: Generate the streak card
+        env:
+          TOKEN: ${{ secrets.GH_STATS_TOKEN }}
+        run: |
+          php .streak-generator/bin/generate-card.php \
+            --options="user=${GITHUB_REPOSITORY_OWNER}&theme=radical&hide_border=true" \
+            --path=github-streak-stats.svg
+
+      - name: Generate the contribution snakes
+        uses: Platane/snk/svg-only@d8f6715049803e982ee5ff501b6b9b7d5deeb09b # v3
+        with:
+          github_user_name: ${{ github.repository_owner }}
+          outputs: |
+            github-contribution-grid-snake.svg?palette=github-light&color_snake=#ea580c&color_dots=#ebedf0,#fed7aa,#fdba74,#fb923c,#c2410c
+            github-contribution-grid-snake-dark.svg?palette=github-dark&color_snake=#fb923c&color_dots=#161b22,#431407,#7c2d12,#c2410c,#fb923c
+
+      - name: Publish changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add github-streak-stats.svg github-contribution-grid-snake.svg github-contribution-grid-snake-dark.svg
+
+          if git diff --cached --quiet; then
+            echo "Streak card is already current."
+            exit 0
+          fi
+
+          git commit -m "chore(profile): refresh GitHub visuals"
+          git push origin HEAD:output

--- a/.well-known/project.json
+++ b/.well-known/project.json
@@ -1,32 +1,16 @@
 {
-  "founder": "Oskar Arnetz",
-  "role": "CTO & Co-founder",
-  "domain": "Vertical SaaS & AI",
-  "tech": [
-    "TypeScript",
-    "Flutter",
-    "Dart",
-    "Firebase",
-    "AI",
-    "iOS",
-    "Android",
-    "Web"
+  "name": "Oskar Arnetz",
+  "role": "Product engineer",
+  "focus": [
+    "Applied AI",
+    "Product engineering",
+    "Systems integration",
+    "Cloud architecture"
   ],
-  "stage": "pre-seed",
-  "public": true,
-  "funding": "€300,000",
-  "expertise": [
-    "SaaS",
-    "AI Integration",
-    "Cloud Security",
-    "Mobile Development"
+  "principles": [
+    "Pragmatic delivery",
+    "Reliable systems",
+    "Useful outcomes"
   ],
-  "industries": [
-    "Ecommerce",
-    "SAAS",
-    "Fintech",
-    "MedTech",
-    "Automotive",
-    "Retail"
-  ]
+  "public": true
 }

--- a/README.md
+++ b/README.md
@@ -1,290 +1,113 @@
-<p align="center"><em>Copenhagen · Europe/Stockholm (CET/CEST)</em></p>
-
-<div align="center" style="max-width:100%;padding:1rem;">
-  <img
-    src="https://capsule-render.vercel.app/api?type=venom&height=250&text=Oskar%20Arnetz&fontSize=75&color=gradient&animation=fadeIn"
-    alt="Oskar Arnetz — Applied AI / Product Engineering"
-    style="width:100%;max-width:1200px;height:auto;"
-  />
-</div>
-
-<div align="center" style="margin-top:-30px;">
-  <img
-    src="https://readme-typing-svg.herokuapp.com?font=Fira+Code&pause=1100&color=F75C7E&center=true&vCenter=true&width=920&lines=Applied+AI+%7C+Product+Engineering;Messy+workflows+%E2%86%92+shipped+software;AI+agents+%C2%B7+integrations+%C2%B7+cloud+%C2%B7+APIs;5+production+products+shipped+%C2%B7+%E2%82%AC300K+raised;Less+theatre+%C2%B7+more+useful+systems"
-    alt="Typing intro for Oskar Arnetz"
-    style="max-width:100%;height:auto;"
-  />
-</div>
-
-<div align="center" style="margin:1rem;display:flex;flex-wrap:wrap;justify-content:center;gap:10px;">
-  <a href="https://www.linkedin.com/in/oskar-arnetz/" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/badge/LinkedIn-Message%20me-blue?style=for-the-badge&logo=linkedin" alt="LinkedIn — message Oskar Arnetz"/>
-  </a>
-  <a href="https://github.com/OskaraOskar" target="_blank" rel="noopener">
-    <img src="https://img.shields.io/badge/GitHub-OskaraOskar-black?style=for-the-badge&logo=github" alt="GitHub — Oskar Arnetz"/>
-  </a>
-</div>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./assets/profile-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="./assets/profile-light.svg">
+  <img src="./assets/profile-light.svg" alt="Animated orange paths converging into a simple line beneath the name Oskar Arnetz." width="100%">
+</picture>
 
 <p align="center">
-  Say <strong>hi</strong> on LinkedIn. A short message in your connections requests goes a long way. No pitch deck required.
+  <a href="https://www.linkedin.com/in/oskar-arnetz/"><img src="https://img.shields.io/badge/LinkedIn-Say%20hello-f97316?style=for-the-badge&logo=linkedin&logoColor=white" alt="Message Oskar Arnetz on LinkedIn"></a>
+  <a href="https://github.com/OskaraOskar"><img src="https://img.shields.io/badge/GitHub-OskaraOskar-262626?style=for-the-badge&logo=github&logoColor=white" alt="Oskar Arnetz on GitHub"></a>
 </p>
 
-<hr/>
+<h3 align="center">A bit about me</h3>
 
-<h2 align="center">What I Do</h2>
+I tend to choose the simplest approach that actually works. That means moving quickly when a decision is cheap, slowing down when mistakes are expensive, and leaving enough room to change course later.
 
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  I build software for messy and unknown real-world workflows.
-  Usually, that means taking vague problems, figuring out what actually matters,
-  and turning them into products, APIs, integrations, automations, or AI systems that people can use.
-</p>
+I care about finishing things, but not at the cost of making tomorrow harder than it needs to be. What deserves extra time depends on the problem.
 
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  AI is useful when it makes the workflow better, as is code, but just like movies and CGI, use it sparingly and when needed
-  Otherwise, it is just expensive autocomplete.
-</p>
+<h3 align="center">Where things get interesting</h3>
 
-<hr/>
+I like the moment when something complicated starts to feel simple. Not simplified by ignoring the awkward parts, but made understandable because the awkward parts have been worked through.
 
-<h2 align="center">Now</h2>
+<table>
+  <tr>
+    <td width="33%" valign="top">
+      <h3>Business logic</h3>
+      APIs are rarely the hard part. The real work is in the exceptions, handoffs, conflicting rules, missing information, and the gap between the documented process and what people actually do.
+    </td>
+    <td width="33%" valign="top">
+      <h3>Applied AI</h3>
+      The demo is usually easy. Things get interesting when the model has to be useful inside a real workflow, with sensible guardrails, clear failure states, and a reason to be there.
+    </td>
+    <td width="33%" valign="top">
+      <h3>The whole product</h3>
+      Sometimes the simple answer only appears when product, UX, backend, data, infrastructure, integrations, and operations are treated as one problem instead of separate tickets.
+    </td>
+  </tr>
+</table>
 
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  Forward-deployed / product engineering work around <strong>AI agents</strong>,
-  <strong>integrations</strong>, <strong>customer workflows</strong>, and <strong>production systems</strong>.
-</p>
+There is beauty in a system that feels obvious on the outside, even when a lot of careful thinking was required to make it feel that way.
 
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  Best fit: small senior teams, fast decisions, high ownership, real users.
-  I like problems where the shape is still unclear.
-</p>
+<h3 align="center">Receipts</h3>
 
-<hr/>
-
-<h2 align="center">Selected Work</h2>
-
-<ul style="max-width:900px;margin:auto;list-style:none;padding:0;line-height:1.9;">
-  <li>
-    <strong>Shipped 5 production products from 2023–2026</strong> across B2B and consumer,
-    owning architecture, product, UX/UI, infrastructure, integrations, and deployment.
-  </li>
-  <li>
-    <strong>Built applied AI systems inside real workflows</strong> across FinTech, Fashion, MusicTech,
-    entertainment operations, analytics, and internal automation.
-  </li>
-  <li>
-    <strong>Designed and built AI search / product-validation tools</strong> for finding whether real problems
-    are being discussed across forums, blogs, search results, and public data sources.
-  </li>
-  <li>
-    <strong>Built AI voice → transcript → task/workflow systems</strong> for production teams where misalignment
-    is expensive and manual follow-up is slow.
-  </li>
-  <li>
-    <strong>Designed API and integration layers</strong> between banks, POS systems, transaction data,
-    receipt-level details, and downstream data consumers.
-  </li>
-  <li>
-    <strong>Built analytics products for operational users</strong>, including mobile analytics used across
-    multiple markets by store managers, regional leaders, and executive leadership.
-  </li>
-</ul>
-
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  Most of the interesting code is private, client-owned, or startup-owned.
-  The work is usually less “look at my repo” and more “make this thing work in production.”
-</p>
-
-<hr/>
-
-<div align="center" style="display:flex;flex-wrap:wrap;justify-content:center;">
-  <p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  If you wonder how you get 212 commits in 1 day? Rebase and squash, my friend, rebase and squash.
-</p>
-  <img
-    src="https://github.com/OskaraOskar/OskaraOskar/blob/output/github-streak-stats.svg"
-    alt="GitHub streak stats"
-    style="width:100%;max-width:900px;border-radius:6px;height:auto;"
-  />
-</div>
-
-<hr/>
-
-<h2 align="center">Technical</h2>
-
-<!--
-Icons: skillicons.dev can intermittently fail; this section uses jsDelivr-backed SVGs for better reliability.
--->
-
-<div align="center" style="background:linear-gradient(180deg,#0d1117 0%,#161b22 100%);padding:20px;border-radius:10px;color:#fff;max-width:1000px;margin:auto;">
-  <div style="display:flex;flex-direction:column;align-items:center;gap:40px;width:100%;margin:auto;">
-    <!-- Languages -->
-    <div style="width:100%;text-align:center;">
-      <h4>Languages I Actually Reach For</h4>
-      <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:12px;">
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" alt="TypeScript"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/dart/dart-original.svg" alt="Dart"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg" alt="C#"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/solidity/solidity-original.svg" alt="Solidity"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="HTML"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" alt="CSS"/>
-      </div>
-    </div>
-    <!-- Core Stack -->
-    <div style="width:100%;text-align:center;">
-      <h4>Core Product Stack</h4>
-      <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:12px;">
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/flutter/flutter-original.svg" alt="Flutter"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg" alt="React"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/firebase/firebase-plain.svg" alt="Firebase"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecloud/googlecloud-original.svg" alt="Google Cloud"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/amazonwebservices/amazonwebservices-original.svg" alt="AWS"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" alt="Docker"/>
-      </div>
-    </div>
-    <!-- AI -->
-    <div style="width:100%;text-align:center;">
-      <h4>AI & Applied Intelligence</h4>
-      <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:12px;">
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecloud/googlecloud-original.svg" alt="Google Cloud"/>
-      </div>
-      <div style="margin-top:8px;display:flex;flex-wrap:wrap;justify-content:center;gap:8px;">
-        <img src="https://img.shields.io/badge/Gemini-AI-blueviolet?style=flat-square&logo=googlecloud" alt="Gemini AI"/>
-        <img src="https://img.shields.io/badge/Claude-AI-9146FF?style=flat-square&logo=anthropic" alt="Claude AI"/>
-        <img src="https://img.shields.io/badge/OpenAI-GPT-00A67E?style=flat-square&logo=openai" alt="OpenAI GPT"/>
-      </div>
-      <p style="max-width:760px;margin:12px auto 0 auto;line-height:1.7;">
-        Agents · summarization · classification · search · workflow automation · data extraction · guardrails · usefulness over vibes
-      </p>
-    </div>
-    <!-- Media & Integrations -->
-    <div style="width:100%;text-align:center;">
-      <h4>Integrations · External Systems</h4>
-      <p style="max-width:760px;margin:12px auto 0 auto;line-height:1.7;">
-        APIs, webhooks, scheduled jobs, ugly data, auth flows, retries, edge cases, and the annoying parts that make products real.
-      </p>
-    </div>
-    <!-- Tools & Workflow -->
-    <div style="width:100%;text-align:center;">
-      <h4>Tools & Workflow</h4>
-      <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:12px;">
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="Git"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" alt="GitHub"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" alt="VSCode"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/figma/figma-original.svg" alt="Figma"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/notion/notion-original.svg" alt="Notion"/>
-        <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg" alt="Postman"/>
-      </div>
-    </div>
-    <!-- Visual Metrics -->
-    <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:16px;width:100%;">
-      <img src="https://github.com/OskaraOskar/OskaraOskar/blob/output/github-top-langs.svg"
-           alt="Top languages chart"
-           style="width:100%;max-width:480px;flex:1;border-radius:6px;height:auto;"/>
-      <img src="https://github.com/OskaraOskar/OskaraOskar/blob/output/github-contribution-grid-snake.svg"
-           alt="Contribution snake"
-           style="width:100%;max-width:480px;flex:1;border-radius:6px;height:auto;"/>
-    </div>
-    <!-- Skyline -->
-    <div style="width:100%;text-align:center;">
-      <img src="https://github.com/OskaraOskar/OskaraOskar/blob/output/metrics.skyline.svg"
-           alt="GitHub skyline visualization"
-           style="width:100%;height:auto;border-radius:6px;"/>
-    </div>
-  </div>
-</div>
-
-<hr/>
-
-<h2 align="center">How I Like To Work</h2>
-
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  Fast. Direct. Close to users.
-</p>
-
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  Give me the problem, the context, and the constraints.
-  I will find a path through the mess and build what needs to exist.
-</p>
-
-<p align="center" style="max-width:900px;margin:auto;line-height:1.8;">
-  I am less useful in environments where progress requires five meetings about the meeting.
-</p>
-
-<hr/>
-
-<!-- Fun section (kept as an optional footer element) -->
-<div align="center" style="margin-top:1rem;">
-  <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:16px;max-width:900px;margin:auto;">
-    <img src="https://readme-jokes.vercel.app/api?theme=radical"
-         alt="Jokes card"
-         style="flex:1;min-width:280px;max-width:420px;border-radius:6px;height:auto;"/>
-    <img src="https://quotes-github-readme.vercel.app/api?type=horizontal&theme=radical"
-         alt="Quote card"
-         style="flex:1;min-width:280px;max-width:420px;border-radius:6px;height:auto;"/>
-  </div>
-</div>
-
-<hr/>
+Most of my work lives in private repositories, so GitHub only tells part of the story. These visuals refresh every night, and the streak includes private contribution counts.
 
 <p align="center">
-  <img src="https://komarev.com/ghpvc/?username=OskaraOskar&style=flat-square&color=blue" alt="Profile views"/>
-  <img src="https://img.shields.io/github/followers/OskaraOskar?label=Followers&style=social" alt="GitHub followers"/>
+  <img src="https://raw.githubusercontent.com/OskaraOskar/OskaraOskar/output/github-streak-stats.svg" alt="GitHub contribution streak for Oskar Arnetz, including private contribution counts and updated nightly." width="495">
 </p>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/OskaraOskar/OskaraOskar/output/github-contribution-grid-snake-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/OskaraOskar/OskaraOskar/output/github-contribution-grid-snake.svg">
+  <img src="https://raw.githubusercontent.com/OskaraOskar/OskaraOskar/output/github-contribution-grid-snake.svg" alt="Animated GitHub contribution graph for Oskar Arnetz." width="100%">
+</picture>
+
+<p align="center"><sub>If you ever see 212 commits in one day: rebase and squash, my friend. Rebase and squash.</sub></p>
+
+<h3 align="center">Toolbox</h3>
+
+These are the tools I reach for most often, not the edge of what I know. I have learned and experimented with plenty of others, from Solidity to building my own basic AI system years ago.
+
+If a problem calls for something else, I am comfortable learning it.
+
+<p align="center"><strong>Languages</strong></p>
 
 <p align="center">
-  Best place to reach me is LinkedIn.
-  Short message. Real context. No corporate poem.
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" alt="TypeScript" title="TypeScript">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" title="JavaScript">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" title="Python">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg" alt="C sharp" title="C sharp">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/dart/dart-original.svg" alt="Dart" title="Dart">
 </p>
+
+<p align="center"><strong>Products and platforms</strong></p>
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/oskar-arnetz/">linkedin.com/in/oskar-arnetz</a>
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg" alt="React" title="React">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/flutter/flutter-original.svg" alt="Flutter" title="Flutter">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/firebase/firebase-plain.svg" alt="Firebase" title="Firebase">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/googlecloud/googlecloud-original.svg" alt="Google Cloud" title="Google Cloud">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/amazonwebservices/amazonwebservices-original-wordmark.svg" alt="AWS" title="AWS">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" alt="Docker" title="Docker">
 </p>
 
-<!--
-discovery-keywords:
-oskar arnetz;
-applied ai;
-ai agents;
-pragmatic ai;
-product engineering;
-workflow automation;
-b2b saas;
-systems design;
-integrations;
-api design;
-rest api;
-cloud architecture;
-gcp;
-google cloud;
-firebase;
-aws;
-docker;
-typescript;
-javascript;
-python;
-dart;
-flutter;
-react;
-csharp;
-dotnet;
-ffmpeg;
-media pipelines;
-tiktok api;
-instagram api;
-facebook api;
-threads api;
-bluesky api;
-forward deployed engineer;
-founding engineer;
-cto;
-startup;
-builder;
-copenhagen;
-malmo;
-sweden;
-denmark;
-europe
--->
+<p align="center"><strong>Tools</strong></p>
+
+<p align="center">
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="Git" title="Git">
+  &nbsp;
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.simpleicons.org/github/f5f5f5">
+    <source media="(prefers-color-scheme: light)" srcset="https://cdn.simpleicons.org/github/181717">
+    <img height="44" src="https://cdn.simpleicons.org/github/181717" alt="GitHub" title="GitHub">
+  </picture>
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" alt="Visual Studio Code" title="Visual Studio Code">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/figma/figma-original.svg" alt="Figma" title="Figma">
+  &nbsp;
+  <img height="44" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg" alt="Postman" title="Postman">
+</p>
+
+<h3 align="center">Say hello</h3>
+
+I am based in Copenhagen and work on Europe/Stockholm time. The easiest way to reach me is [LinkedIn](https://www.linkedin.com/in/oskar-arnetz/). A short message with a little context is plenty.

--- a/assets/profile-dark.svg
+++ b/assets/profile-dark.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" role="img" aria-labelledby="title desc">
+  <title id="title">Oskar Arnetz profile header</title>
+  <desc id="desc">Orange and gray paths move from several curves into one clear line beneath Oskar Arnetz's name.</desc>
+  <defs>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#404040" stroke-width="1" opacity=".35"/>
+    </pattern>
+    <linearGradient id="fade" x1="0" x2="1">
+      <stop offset="0" stop-color="#fb923c" stop-opacity="0"/>
+      <stop offset=".18" stop-color="#fb923c"/>
+      <stop offset="1" stop-color="#f97316"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="7" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <clipPath id="frame"><rect x="1" y="1" width="1198" height="298" rx="24"/></clipPath>
+    <style>
+      .moving { stroke-dasharray: 14 18; animation: move 2.6s linear infinite; }
+      .pulse { animation: pulse 2.6s ease-in-out infinite; transform-origin: 600px 225px; }
+      @keyframes move { to { stroke-dashoffset: -64; } }
+      @keyframes pulse { 0%,100% { opacity:.55; transform:scale(.82); } 50% { opacity:1; transform:scale(1.12); } }
+    </style>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="298" rx="24" fill="#171717" stroke="#404040" stroke-width="2"/>
+  <g clip-path="url(#frame)">
+    <rect width="1200" height="300" fill="url(#grid)"/>
+    <circle cx="600" cy="80" r="76" fill="#f97316" opacity=".08" filter="url(#glow)"/>
+
+    <text x="600" y="112" fill="#fafaf9" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="76" font-weight="760" text-anchor="middle" letter-spacing="-2">Oskar Arnetz</text>
+    <rect x="498" y="132" width="204" height="5" rx="2.5" fill="#f97316"/>
+    <text x="600" y="168" fill="#a3a3a3" font-family="ui-monospace,SFMono-Regular,Consolas,monospace" font-size="16" text-anchor="middle" letter-spacing="2">COPENHAGEN &#183; EUROPE/STOCKHOLM</text>
+
+    <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M54 214 C132 162 193 270 275 216 S421 168 507 225 C545 250 566 237 600 225" stroke="#737373" stroke-width="4" opacity=".75"/>
+      <path d="M54 251 C146 280 186 176 282 226 S430 275 512 222 C548 199 571 212 600 225" stroke="#fafaf9" stroke-width="4" opacity=".92"/>
+      <path d="M54 184 C154 178 177 242 274 241 S417 194 507 218 C548 229 568 229 600 225" stroke="#f97316" stroke-width="6" opacity=".95"/>
+      <path d="M600 225 H1123" stroke="#525252" stroke-width="4"/>
+      <path class="moving" d="M600 225 H1123" stroke="url(#fade)" stroke-width="7"/>
+      <path d="M1110 212 L1124 225 L1110 238" stroke="#fb923c" stroke-width="6"/>
+    </g>
+
+    <g fill="#171717" stroke-width="4">
+      <circle cx="54" cy="184" r="7" stroke="#f97316"/>
+      <circle cx="54" cy="214" r="7" stroke="#737373"/>
+      <circle cx="54" cy="251" r="7" stroke="#fafaf9"/>
+    </g>
+    <circle class="pulse" cx="600" cy="225" r="17" fill="#f97316" opacity=".8"/>
+    <circle cx="600" cy="225" r="6" fill="#fafaf9"/>
+  </g>
+</svg>

--- a/assets/profile-light.svg
+++ b/assets/profile-light.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" role="img" aria-labelledby="title desc">
+  <title id="title">Oskar Arnetz profile header</title>
+  <desc id="desc">Orange and gray paths move from several curves into one clear line beneath Oskar Arnetz's name.</desc>
+  <defs>
+    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
+      <path d="M30 0H0V30" fill="none" stroke="#d6d3d1" stroke-width="1" opacity=".55"/>
+    </pattern>
+    <linearGradient id="fade" x1="0" x2="1">
+      <stop offset="0" stop-color="#c2410c" stop-opacity="0"/>
+      <stop offset=".18" stop-color="#c2410c"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="7" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <clipPath id="frame"><rect x="1" y="1" width="1198" height="298" rx="24"/></clipPath>
+    <style>
+      .moving { stroke-dasharray: 14 18; animation: move 2.6s linear infinite; }
+      .pulse { animation: pulse 2.6s ease-in-out infinite; transform-origin: 600px 225px; }
+      @keyframes move { to { stroke-dashoffset: -64; } }
+      @keyframes pulse { 0%,100% { opacity:.55; transform:scale(.82); } 50% { opacity:1; transform:scale(1.12); } }
+    </style>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="298" rx="24" fill="#fafaf9" stroke="#d6d3d1" stroke-width="2"/>
+  <g clip-path="url(#frame)">
+    <rect width="1200" height="300" fill="url(#grid)"/>
+    <circle cx="600" cy="80" r="76" fill="#ea580c" opacity=".08" filter="url(#glow)"/>
+
+    <text x="600" y="112" fill="#1c1917" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="76" font-weight="760" text-anchor="middle" letter-spacing="-2">Oskar Arnetz</text>
+    <rect x="498" y="132" width="204" height="5" rx="2.5" fill="#c2410c"/>
+    <text x="600" y="168" fill="#57534e" font-family="ui-monospace,SFMono-Regular,Consolas,monospace" font-size="16" text-anchor="middle" letter-spacing="2">COPENHAGEN &#183; EUROPE/STOCKHOLM</text>
+
+    <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M54 214 C132 162 193 270 275 216 S421 168 507 225 C545 250 566 237 600 225" stroke="#78716c" stroke-width="4" opacity=".75"/>
+      <path d="M54 251 C146 280 186 176 282 226 S430 275 512 222 C548 199 571 212 600 225" stroke="#1c1917" stroke-width="4" opacity=".92"/>
+      <path d="M54 184 C154 178 177 242 274 241 S417 194 507 218 C548 229 568 229 600 225" stroke="#c2410c" stroke-width="6" opacity=".95"/>
+      <path d="M600 225 H1123" stroke="#d6d3d1" stroke-width="4"/>
+      <path class="moving" d="M600 225 H1123" stroke="url(#fade)" stroke-width="7"/>
+      <path d="M1110 212 L1124 225 L1110 238" stroke="#c2410c" stroke-width="6"/>
+    </g>
+
+    <g fill="#fafaf9" stroke-width="4">
+      <circle cx="54" cy="184" r="7" stroke="#c2410c"/>
+      <circle cx="54" cy="214" r="7" stroke="#78716c"/>
+      <circle cx="54" cy="251" r="7" stroke="#1c1917"/>
+    </g>
+    <circle class="pulse" cx="600" cy="225" r="17" fill="#ea580c" opacity=".8"/>
+    <circle cx="600" cy="225" r="6" fill="#fafaf9"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- refresh the profile README with an animated orange theme and compact visual layout
- reorganize the profile copy around practical simplicity and real-world complexity
- add a theme-aware visual toolbox
- retain the private-count streak and add light and dark contribution animations
- simplify the public profile metadata

## Verification

- reviewed the complete README on GitHub in dark mode
- rendered and reviewed both local SVG themes
- verified all toolbox SVGs are reachable
- validated Markdown wording, JSON, YAML, and SVG XML
- confirmed all workflow actions are pinned to full commit SHAs
- completed the profile visual workflow with zero annotations
- ran `git diff --check`

## Review focus

Please check the README presentation, wording, and nightly profile visual workflow.